### PR TITLE
Initial dataframe support for query_variant_calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
     # Build and Test R package
     - R CMD build .
-    - R CMD INSTALL --configure-args="--with-genomicsdb=${GENOMICSDB_HOME}"  genomicsdb_0.0.2.tar.gz
-    - R CMD check --no-manual --install-args="--configure-args='--with-genomicsdb=${GENOMICSDB_HOME}'" genomicsdb_0.0.2.tar.gz
+    - R CMD INSTALL --configure-args="--with-genomicsdb=${GENOMICSDB_HOME}"  genomicsdb_0.0.3.tar.gz
+    - R CMD check --no-manual --install-args="--configure-args='--with-genomicsdb=${GENOMICSDB_HOME}'" genomicsdb_0.0.3.tar.gz
     - R -e 'library(devtools); devtools::test()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: genomicsdb
 Type: Package
 Title: GenomicsDB R Bindings
-Version: 0.0.2
+Version: 0.0.3
 Date: 2019-04-17
 Author: N G
 Maintainer: nalinigans <nalinigans@github.com>

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -21,16 +21,24 @@ query_variants <- function(genomicsdb, array, column_ranges, row_ranges) {
     .Call(`_genomicsdb_query_variants`, genomicsdb, array, column_ranges, row_ranges)
 }
 
-query_variant_calls_json <- function(genomicsdb) {
-    .Call(`_genomicsdb_query_variant_calls_json`, genomicsdb)
-}
-
 query_variant_calls <- function(genomicsdb, array, column_ranges, row_ranges) {
     .Call(`_genomicsdb_query_variant_calls`, genomicsdb, array, column_ranges, row_ranges)
 }
 
-generate_vcf <- function(genomicsdb, output, output_format, overwrite) {
-    invisible(.Call(`_genomicsdb_generate_vcf`, genomicsdb, output, output_format, overwrite))
+query_variant_calls_json <- function(genomicsdb) {
+    .Call(`_genomicsdb_query_variant_calls_json`, genomicsdb)
+}
+
+query_variant_calls_by_interval <- function(genomicsdb, array, column_ranges, row_ranges) {
+    .Call(`_genomicsdb_query_variant_calls_by_interval`, genomicsdb, array, column_ranges, row_ranges)
+}
+
+generate_vcf <- function(genomicsdb, array, column_ranges, row_ranges, output, output_format, overwrite) {
+    invisible(.Call(`_genomicsdb_generate_vcf`, genomicsdb, array, column_ranges, row_ranges, output, output_format, overwrite))
+}
+
+generate_vcf_json <- function(genomicsdb, output, output_format, overwrite) {
+    invisible(.Call(`_genomicsdb_generate_vcf_json`, genomicsdb, output, output_format, overwrite))
 }
 
 rcpp_hello_world <- function() {

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ fi
 
 echo "Using GENOMICSDB_HOME=${GENOMICSDB_HOME}"
 
-# R -e 'library(Rcpp); compileAttributes(".")'
+R -e 'library(Rcpp); compileAttributes(".")'
 R CMD build . &&
-R CMD INSTALL --preclean --configure-args="--with-genomicsdb=${GENOMICSDB_HOME}" genomicsdb_0.0.2.tar.gz &&
-R CMD check --no-manual --install-args="--configure-args='--with-genomicsdb=${GENOMICSDB_HOME}'" genomicsdb_0.0.2.tar.gz &&
+R CMD INSTALL --preclean --configure-args="--with-genomicsdb=${GENOMICSDB_HOME}" genomicsdb_0.0.3.tar.gz &&
+R CMD check --no-manual --install-args="--configure-args='--with-genomicsdb=${GENOMICSDB_HOME}'" genomicsdb_0.0.3.tar.gz &&
 R -e 'library(devtools); test()'

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -69,19 +69,8 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// query_variant_calls_json
-Rcpp::List query_variant_calls_json(Rcpp::XPtr<GenomicsDB> genomicsdb);
-RcppExport SEXP _genomicsdb_query_variant_calls_json(SEXP genomicsdbSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::XPtr<GenomicsDB> >::type genomicsdb(genomicsdbSEXP);
-    rcpp_result_gen = Rcpp::wrap(query_variant_calls_json(genomicsdb));
-    return rcpp_result_gen;
-END_RCPP
-}
 // query_variant_calls
-Rcpp::List query_variant_calls(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& array, Rcpp::List column_ranges, Rcpp::List row_ranges);
+Rcpp::DataFrame query_variant_calls(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& array, Rcpp::List column_ranges, Rcpp::List row_ranges);
 RcppExport SEXP _genomicsdb_query_variant_calls(SEXP genomicsdbSEXP, SEXP arraySEXP, SEXP column_rangesSEXP, SEXP row_rangesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -94,16 +83,57 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// query_variant_calls_json
+Rcpp::DataFrame query_variant_calls_json(Rcpp::XPtr<GenomicsDB> genomicsdb);
+RcppExport SEXP _genomicsdb_query_variant_calls_json(SEXP genomicsdbSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<GenomicsDB> >::type genomicsdb(genomicsdbSEXP);
+    rcpp_result_gen = Rcpp::wrap(query_variant_calls_json(genomicsdb));
+    return rcpp_result_gen;
+END_RCPP
+}
+// query_variant_calls_by_interval
+Rcpp::List query_variant_calls_by_interval(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& array, Rcpp::List column_ranges, Rcpp::List row_ranges);
+RcppExport SEXP _genomicsdb_query_variant_calls_by_interval(SEXP genomicsdbSEXP, SEXP arraySEXP, SEXP column_rangesSEXP, SEXP row_rangesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<GenomicsDB> >::type genomicsdb(genomicsdbSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type column_ranges(column_rangesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type row_ranges(row_rangesSEXP);
+    rcpp_result_gen = Rcpp::wrap(query_variant_calls_by_interval(genomicsdb, array, column_ranges, row_ranges));
+    return rcpp_result_gen;
+END_RCPP
+}
 // generate_vcf
-void generate_vcf(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& output, const std::string& output_format, bool overwrite);
-RcppExport SEXP _genomicsdb_generate_vcf(SEXP genomicsdbSEXP, SEXP outputSEXP, SEXP output_formatSEXP, SEXP overwriteSEXP) {
+void generate_vcf(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& array, Rcpp::List column_ranges, Rcpp::List row_ranges, const std::string& output, const std::string& output_format, bool overwrite);
+RcppExport SEXP _genomicsdb_generate_vcf(SEXP genomicsdbSEXP, SEXP arraySEXP, SEXP column_rangesSEXP, SEXP row_rangesSEXP, SEXP outputSEXP, SEXP output_formatSEXP, SEXP overwriteSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<GenomicsDB> >::type genomicsdb(genomicsdbSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type column_ranges(column_rangesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type row_ranges(row_rangesSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type output(outputSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type output_format(output_formatSEXP);
+    Rcpp::traits::input_parameter< bool >::type overwrite(overwriteSEXP);
+    generate_vcf(genomicsdb, array, column_ranges, row_ranges, output, output_format, overwrite);
+    return R_NilValue;
+END_RCPP
+}
+// generate_vcf_json
+void generate_vcf_json(Rcpp::XPtr<GenomicsDB> genomicsdb, const std::string& output, const std::string& output_format, bool overwrite);
+RcppExport SEXP _genomicsdb_generate_vcf_json(SEXP genomicsdbSEXP, SEXP outputSEXP, SEXP output_formatSEXP, SEXP overwriteSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<GenomicsDB> >::type genomicsdb(genomicsdbSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type output(outputSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type output_format(output_formatSEXP);
     Rcpp::traits::input_parameter< bool >::type overwrite(overwriteSEXP);
-    generate_vcf(genomicsdb, output, output_format, overwrite);
+    generate_vcf_json(genomicsdb, output, output_format, overwrite);
     return R_NilValue;
 END_RCPP
 }
@@ -133,9 +163,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_genomicsdb_connect_with_query_json", (DL_FUNC) &_genomicsdb_connect_with_query_json, 3},
     {"_genomicsdb_disconnect", (DL_FUNC) &_genomicsdb_disconnect, 1},
     {"_genomicsdb_query_variants", (DL_FUNC) &_genomicsdb_query_variants, 4},
-    {"_genomicsdb_query_variant_calls_json", (DL_FUNC) &_genomicsdb_query_variant_calls_json, 1},
     {"_genomicsdb_query_variant_calls", (DL_FUNC) &_genomicsdb_query_variant_calls, 4},
-    {"_genomicsdb_generate_vcf", (DL_FUNC) &_genomicsdb_generate_vcf, 4},
+    {"_genomicsdb_query_variant_calls_json", (DL_FUNC) &_genomicsdb_query_variant_calls_json, 1},
+    {"_genomicsdb_query_variant_calls_by_interval", (DL_FUNC) &_genomicsdb_query_variant_calls_by_interval, 4},
+    {"_genomicsdb_generate_vcf", (DL_FUNC) &_genomicsdb_generate_vcf, 7},
+    {"_genomicsdb_generate_vcf_json", (DL_FUNC) &_genomicsdb_generate_vcf_json, 4},
     {"_genomicsdb_rcpp_hello_world", (DL_FUNC) &_genomicsdb_rcpp_hello_world, 0},
     {"_genomicsdb_rcpp_vector_access1", (DL_FUNC) &_genomicsdb_rcpp_vector_access1, 0},
     {NULL, NULL, 0}

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -23,10 +23,23 @@ test_that("test that genomicsdb connects to an existing workspace for queries", 
 
     # Test Query VariantCalls - Return List of Query Intervals by Row
     variantcalls <- genomicsdb::query_variant_calls(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,1000000000)), row_ranges=list(c(0,3)))
+    expect_length(variantcalls, 9) # Number of columns
+    expect_true(nrow(variantcalls) == 5) # Number of rows
+          
+    variantcalls <- genomicsdb::query_variant_calls_by_interval(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,1000000000)), row_ranges=list(c(0,3)))
     expect_length(variantcalls, 1)
-    
+
     variantcalls1 <- genomicsdb::query_variant_calls(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,150000), c(15001, 1000000000)), row_ranges=list(c(0,3)))
+    expect_length(variantcalls1, 9) # Number of columns
+    expect_true(nrow(variantcalls1) == 8) # Number of rows
+    variantcalls1 <- genomicsdb::query_variant_calls_by_interval(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,150000), c(15001, 1000000000)), row_ranges=list(c(0,3)))
     expect_length(variantcalls1, 1)
+
+    # Test generate_vcf
+    output <- "generated_no_spark.vcf.gz"
+    genomicsdb::generate_vcf(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,150000), c(15001, 1000000000)), row_ranges=list(c(0,3)), output=output, output_format="z", overwrite=FALSE)
+    expect_true(file.exists(output))
+    expect_true(file.exists(paste(output,".tbi",sep="")))
     
     genomicsdb::disconnect(genomicsdb=gdb)
 })
@@ -37,10 +50,12 @@ test_that("test that genomicsdb can output genotypes as strings", {
 
     # Test Query Variants - Returns List of Query Intervals by Row
     variantcalls <- genomicsdb::query_variant_calls(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,150000), c(15001, 1000000000)), row_ranges=list(c(0,3)))
+    expect_length(variantcalls, 10) # Number of columns
+    expect_true(nrow(variantcalls) == 8) # Number of rows
+    print(variantcalls)
+    
+    variantcalls <- genomicsdb::query_variant_calls_by_interval(genomicsdb=gdb, array="t0_1_2", column_ranges=list(c(0,150000), c(15001, 1000000000)), row_ranges=list(c(0,3)))
     expect_length(variantcalls, 1)
-    print("Variant Calls...")
-    print(variantcalls[1][1]$`Query Interval`)
-    print("Variant Calls Done")
     
     genomicsdb::disconnect(genomicsdb=gdb)
 })
@@ -51,7 +66,7 @@ test_that("test that genomicsdb connect to an existing workspace through query j
     expect_type(gdb, "externalptr")
 
     output <- "no_spark.vcf.gz"
-    genomicsdb::generate_vcf(genomicsdb=gdb, output=output, output_format="z", overwrite=FALSE)
+    genomicsdb::generate_vcf_json(genomicsdb=gdb, output=output, output_format="z", overwrite=FALSE)
     expect_true(file.exists(output))
     expect_true(file.exists(paste(output,".tbi",sep="")))
     


### PR DESCRIPTION
Added initial support for returning data frames via Rcpp. Example data frame -
```
  ROW   COL  SAMPLE CHROM   POS   END REF            ALT  DP  GT
1   0 12140 HG00141     1 12141 12295   C    [<NON_REF>]  NA 0/0
2   1 12144 HG01958     1 12145 12277   C    [<NON_REF>]  NA 0/0
3   0 17384 HG00141     1 17385 17385   G [A, <NON_REF>]  NA 0/1
4   1 17384 HG01958     1 17385 17385   G [T, <NON_REF>] 120 1/1
5   2 17384 HG01530     1 17385 17385   G [A, <NON_REF>]  76 0/1
6   0 17384 HG00141     1 17385 17385   G [A, <NON_REF>]  NA 0/1
7   1 17384 HG01958     1 17385 17385   G [T, <NON_REF>] 120 1/1
8   2 17384 HG01530     1 17385 17385   G [A, <NON_REF>]  76 0/1
```
Most of the `columnar` vector construction will be pushed into the C/C++ layer, so other language bindings can take advantage when building data frames.